### PR TITLE
feat: implements openssh supported, tested with ed25519 certs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ russh = { path = "russh" }
 russh-keys = { path = "russh-keys" }
 russh-cryptovec = { path = "cryptovec" }
 russh-config = { path = "russh-config" }
+
+[workspace.dependencies]
+ssh-key = { version = "0.6.6", features = ["ed25519", "rsa"] }

--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -67,6 +67,7 @@ serde = { version = "1.0", features = ["derive"] }
 sha1 = { version = "0.10", features = ["oid"] }
 sha2 = { version = "0.10", features = ["oid"] }
 spki = "0.7"
+ssh-key = { workspace = true }
 thiserror = "1.0"
 tokio = { version = "1.17.0", features = ["io-util", "rt-multi-thread", "time", "net"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -75,6 +75,7 @@ use data_encoding::BASE64_MIME;
 use hmac::{Hmac, Mac};
 use log::debug;
 use sha1::Sha1;
+use ssh_key::Certificate;
 use thiserror::Error;
 
 pub mod ec;
@@ -319,6 +320,17 @@ pub fn load_secret_key<P: AsRef<Path>>(
     let mut secret = String::new();
     secret_file.read_to_string(&mut secret)?;
     decode_secret_key(&secret, password)
+}
+
+/// Load a openssh certificate
+pub fn load_openssh_certificate<P: AsRef<Path>>(
+    cert_: P,
+) -> Result<Certificate, ssh_key::Error> {
+    let mut cert_file = std::fs::File::open(cert_)?;
+    let mut cert = String::new();
+    cert_file.read_to_string(&mut cert)?;
+
+    Certificate::from_openssh(&cert)
 }
 
 fn is_base64_char(c: char) -> bool {

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -40,6 +40,8 @@ russh-cryptovec = { version = "0.7.0", path = "../cryptovec" }
 russh-keys = { version = "0.43.0", path = "../russh-keys" }
 sha1 = "0.10"
 sha2 = "0.10"
+ssh-encoding = { version = "0.2.0" }
+ssh-key = { workspace = true }
 hex-literal = "0.4"
 num-bigint = { version = "0.4", features = ["rand"] }
 subtle = "2.4"

--- a/russh/examples/client_exec_interactive.rs
+++ b/russh/examples/client_exec_interactive.rs
@@ -29,11 +29,13 @@ async fn main() -> Result<()> {
 
     info!("Connecting to {}:{}", cli.host, cli.port);
     info!("Key path: {:?}", cli.private_key);
+    info!("OpenSSH Certificate path: {:?}", cli.openssh_certificate);
 
     // Session is a wrapper around a russh client, defined down below
     let mut ssh = Session::connect(
         cli.private_key,
         cli.username.unwrap_or("root".to_string()),
+        cli.openssh_certificate,
         (cli.host, cli.port),
     )
     .await?;
@@ -86,9 +88,17 @@ impl Session {
     async fn connect<P: AsRef<Path>, A: ToSocketAddrs>(
         key_path: P,
         user: impl Into<String>,
+        openssh_cert_path: Option<P>,
         addrs: A,
     ) -> Result<Self> {
         let key_pair = load_secret_key(key_path, None)?;
+
+        // load ssh certificate
+        let mut openssh_cert = None;
+        if openssh_cert_path.is_some() {
+            openssh_cert = Some(load_openssh_certificate(openssh_cert_path.unwrap())?);
+        }
+
         let config = client::Config {
             inactivity_timeout: Some(Duration::from_secs(5)),
             ..<_>::default()
@@ -98,12 +108,24 @@ impl Session {
         let sh = Client {};
 
         let mut session = client::connect(config, addrs, sh).await?;
-        let auth_res = session
+
+        // use publickey authentication, with or without certificate
+        if openssh_cert.is_none() {
+            let auth_res = session
             .authenticate_publickey(user, Arc::new(key_pair))
             .await?;
 
-        if !auth_res {
-            anyhow::bail!("Authentication failed");
+            if !auth_res {
+                anyhow::bail!("Authentication (with publickey) failed");
+            }
+        } else {
+            let auth_res = session
+            .authenticate_openssh_cert(user, Arc::new(key_pair), openssh_cert.unwrap())
+            .await?;
+
+            if !auth_res {
+                anyhow::bail!("Authentication (with publickey+cert) failed");
+            }
         }
 
         Ok(Self { session })
@@ -196,6 +218,9 @@ pub struct Cli {
 
     #[clap(long, short = 'k')]
     private_key: PathBuf,
+
+    #[clap(long, short = 'o')]
+    openssh_certificate: Option<PathBuf>,
 
     #[clap(multiple = true, index = 2, required = true)]
     command: Vec<String>,

--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use bitflags::bitflags;
 use russh_cryptovec::CryptoVec;
 use russh_keys::{encoding, key};
+use ssh_key::Certificate;
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -79,6 +80,7 @@ pub enum Method {
     None,
     Password { password: String },
     PublicKey { key: Arc<key::KeyPair> },
+    OpenSSHCertificate { key: Arc<key::KeyPair>, cert: Certificate },
     FuturePublicKey { key: key::PublicKey },
     KeyboardInteractive { submethods: String },
     // Hostbased,

--- a/russh/src/cert.rs
+++ b/russh/src/cert.rs
@@ -1,0 +1,60 @@
+use russh_cryptovec::CryptoVec;
+use russh_keys::encoding::Encoding;
+use ssh_encoding::Encode;
+use ssh_key::{Algorithm, Certificate, EcdsaCurve};
+use crate::{key::PubKey, negotiation::Named};
+
+/// OpenSSH certificate for DSA public key
+const CERT_DSA: &str = "ssh-dss-cert-v01@openssh.com";
+
+/// OpenSSH certificate for ECDSA (NIST P-256) public key
+const CERT_ECDSA_SHA2_P256: &str = "ecdsa-sha2-nistp256-cert-v01@openssh.com";
+
+/// OpenSSH certificate for ECDSA (NIST P-384) public key
+const CERT_ECDSA_SHA2_P384: &str = "ecdsa-sha2-nistp384-cert-v01@openssh.com";
+
+/// OpenSSH certificate for ECDSA (NIST P-521) public key
+const CERT_ECDSA_SHA2_P521: &str = "ecdsa-sha2-nistp521-cert-v01@openssh.com";
+
+/// OpenSSH certificate for Ed25519 public key
+const CERT_ED25519: &str = "ssh-ed25519-cert-v01@openssh.com";
+
+/// OpenSSH certificate with RSA public key
+const CERT_RSA: &str = "ssh-rsa-cert-v01@openssh.com";
+
+/// OpenSSH certificate for ECDSA (NIST P-256) U2F/FIDO security key
+const CERT_SK_ECDSA_SHA2_P256: &str = "sk-ecdsa-sha2-nistp256-cert-v01@openssh.com";
+
+/// OpenSSH certificate for Ed25519 U2F/FIDO security key
+const CERT_SK_SSH_ED25519: &str = "sk-ssh-ed25519-cert-v01@openssh.com";
+
+/// None
+const NONE: &str = "none";
+
+impl PubKey for Certificate {
+    fn push_to(&self, buffer: &mut CryptoVec) {
+        let mut cert_encoded = Vec::new();
+        let _ = self.encode(&mut cert_encoded);
+
+        buffer.extend_ssh_string(&cert_encoded);
+    }
+}
+
+impl Named for Certificate {
+    fn name(&self) -> &'static str {
+        match self.algorithm() {
+            Algorithm::Dsa => CERT_DSA,
+            Algorithm::Ecdsa { curve } => match curve {
+                EcdsaCurve::NistP256 => CERT_ECDSA_SHA2_P256,
+                EcdsaCurve::NistP384 => CERT_ECDSA_SHA2_P384,
+                EcdsaCurve::NistP521 => CERT_ECDSA_SHA2_P521,
+            },
+            Algorithm::Ed25519 => CERT_ED25519,
+            Algorithm::Rsa { .. } => CERT_RSA,
+            Algorithm::SkEcdsaSha2NistP256 => CERT_SK_ECDSA_SHA2_P256,
+            Algorithm::SkEd25519 => CERT_SK_SSH_ED25519,
+            Algorithm::Other(algorithm) => NONE,
+            _ => NONE,
+        }
+    }
+}

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -116,6 +116,7 @@ pub mod mac;
 
 mod compression;
 mod key;
+mod cert;
 mod msg;
 mod negotiation;
 mod ssh_read;


### PR DESCRIPTION
## Changes
- Adds support for `OpenSSH Certificates`, via additional method `authenticate_openssh_cert`
- Adds dependencies for `ssh-key` and `ssh-encoding`.
- Updated example `examples/client_exec_interactive.rs` with an optional argument to pass the openssh certificate path.
